### PR TITLE
Set MongoDB port to 18017 during build to avoid conflict.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -510,7 +510,7 @@
                             <goal>start</goal>
                         </goals>
                         <configuration>
-                            <port>28017</port>
+                            <port>18017</port>
                             <databaseDirectory>${basedir}/target</databaseDirectory>
                             <randomPort>false</randomPort>
                             <logging>none</logging>

--- a/server/src/main/resources/test/mongo.properties
+++ b/server/src/main/resources/test/mongo.properties
@@ -1,5 +1,5 @@
 mongo.host=localhost
-mongo.port=28017
+mongo.port=18017
 mongo.db=cprofile
 mongo.connectionsPerHost=8
 mongo.threadsAllowedToBlockForConnectionMultiplier=4


### PR DESCRIPTION
This allow building profile while a MongoDB is running for an application (Profile, Social, etc.) on a normal port pair of 27017 and 28017.
