### PR TITLE
Fixes CRAFTERCMS-915

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <bson.version>2.11.3</bson.version>
+        <bson.version>2.12.4</bson.version>
     </properties>
 
     <dependencies>

--- a/integration-tests/src/main/resources/crafter/profile/extension/server-config.properties
+++ b/integration-tests/src/main/resources/crafter/profile/extension/server-config.properties
@@ -1,4 +1,4 @@
-crafter.profile.mongodb.connection.port=${mongo.port}
+crafter.profile.mongodb.connection.connectionStr=localhost:${mongo.port}
 crafter.profile.mongodb.scripts.paths=classpath:crafter/profile/extension/init-data.js
 crafter.profile.auth.ticket.maxAge=3
 crafter.profile.mail.host=localhost

--- a/server/src/main/resources/crafter/profile/server-config.properties
+++ b/server/src/main/resources/crafter/profile/server-config.properties
@@ -7,10 +7,7 @@ crafter.profile.mongodb.connection.threadsAllowedToBlockForConnectionMultiplier=
 crafter.profile.mongodb.connection.connectTimeout=1000
 crafter.profile.mongodb.connection.writeConcern=JOURNALED
 crafter.profile.mongodb.connection.readPreference=1
-
-crafter.profile.mongodb.connection.host=localhost
-crafter.profile.mongodb.connection.port=27017
-
+crafter.profile.mongodb.connection.connectionStr=localhost:27017
 crafter.profile.mongodb.connection.dbName=crafterprofile
 crafter.profile.mongodb.connection.dbUsername=
 crafter.profile.mongodb.connection.dbPassword=

--- a/server/src/main/resources/crafter/profile/services-context.xml
+++ b/server/src/main/resources/crafter/profile/services-context.xml
@@ -51,20 +51,13 @@
     </bean>
 
 
-    <bean id="crafter.mongoClient" class="com.mongodb.MongoClient">
-        <constructor-arg>
-            <list>
-                <bean class="com.mongodb.ServerAddress">
-                    <constructor-arg value="${crafter.profile.mongodb.connection.host}"/>
-                    <constructor-arg value="${crafter.profile.mongodb.connection.port}"/>
-                </bean>
-            </list>
-        </constructor-arg>
-        <constructor-arg ref="crafter.mongoClientOptionsFactory"/>
+    <bean id="crafter.profile.mongoClient" class="org.craftercms.commons.mongo.MongoClientFactory">
+        <property name="connectionString" value="${crafter.profile.mongodb.connection.connectionStr}"/>
+        <property name="options" ref="crafter.mongoClientOptionsFactory"/>
     </bean>
 
     <bean id="crafter.jongo" class="org.craftercms.commons.mongo.JongoFactoryBean">
-        <property name="mongo" ref="crafter.mongoClient"/>
+        <property name="mongo" ref="crafter.profile.mongoClient"/>
         <property name="username" value="${crafter.profile.mongodb.connection.dbUsername}"/>
         <property name="password" value="${crafter.profile.mongodb.connection.dbPassword}"/>
         <property name="dbName" value="${crafter.profile.mongodb.connection.dbName}"/>
@@ -103,7 +96,7 @@
           parent="crafter.jongoRepositoryBase"/>
 
     <bean id="crafter.mongoInitScriptRunner" class="org.craftercms.commons.mongo.MongoScriptRunner">
-        <property name="mongo" ref="crafter.mongoClient"/>
+        <property name="mongo" ref="crafter.profile.mongoClient"/>
         <property name="dbName" value="${crafter.profile.mongodb.connection.dbName}"/>
         <property name="username" value="${crafter.profile.mongodb.connection.dbUsername}"/>
         <property name="password" value="${crafter.profile.mongodb.connection.dbPassword}"/>


### PR DESCRIPTION
This changes the way Profile connects to Mongo now uses a property
crafter.profile.mongodb.connection.connectionStr
the format of the String is
host:[port],host:[port] if port is not set asumes default (27017)
