### PR TITLE
Add extension/client-config.properties to classpath

### DIFF
--- a/client/src/main/resources/crafter/profile/client-context.xml
+++ b/client/src/main/resources/crafter/profile/client-context.xml
@@ -13,6 +13,7 @@
         <property name="locations">
             <list>
                 <value>classpath:crafter/profile/client-config.properties</value>
+                <value>classpath*:crafter/profile/extension/client-config.properties</value>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
Without this, there is no good way to override the Profile client settings, such as changing host and/or port number of 'crafter.profile.rest.client.url.base'.