### PR TITLE
Security provide cookies fixed:

### DIFF
--- a/security-provider/src/main/java/org/craftercms/security/processors/impl/LoginProcessor.java
+++ b/security-provider/src/main/java/org/craftercms/security/processors/impl/LoginProcessor.java
@@ -170,8 +170,7 @@ public class LoginProcessor implements RequestSecurityProcessor {
     }
 
     protected boolean isLoginRequest(HttpServletRequest request) {
-        return HttpUtils.getRequestUriWithoutContextPath(request).equals(loginUrl) && request.getMethod().equals(
-                loginMethod);
+        return HttpUtils.getRequestUriWithoutContextPath(request).equals(loginUrl) && request.getMethod().equals(loginMethod);
     }
 
     protected String getUsername(HttpServletRequest request) {

--- a/security-provider/src/main/resources/crafter/security/security-context.xml
+++ b/security-provider/src/main/resources/crafter/security/security-context.xml
@@ -123,21 +123,21 @@
 
     <bean id="crafter.ticketCookieManager" class="org.craftercms.commons.http.CookieManager">
         <property name="maxAge" value="${crafter.security.cookie.ticket.maxAge}"/>
-        <property name="path" value="/"/>
+        <property name="path" value="${crafter.security.cookie.ticket.path}"/>
         <property name="secure" value="${crafter.security.cookie.ticket.secure}"/>
         <property name="httpOnly" value="${crafter.security.cookie.ticket.httpOnly}"/>
     </bean>
 
     <bean id="crafter.profileLastModifiedCookieManager" class="org.craftercms.commons.http.CookieManager">
         <property name="maxAge" value="${crafter.security.cookie.profileLastModified.maxAge}"/>
-        <property name="path" value="/"/>
+        <property name="path" value="${crafter.security.cookie.profileLastModified.path}"/>
         <property name="secure" value="${crafter.security.cookie.profileLastModified.secure}"/>
         <property name="httpOnly" value="${crafter.security.cookie.profileLastModified.httpOnly}"/>
     </bean>
 
     <bean id="crafter.rememberMeCookieManager" class="org.craftercms.commons.http.CookieManager">
         <property name="maxAge" value="${crafter.security.cookie.rememberMe.maxAge}"/>
-        <property name="path" value="/"/>
+        <property name="path" value="${crafter.security.cookie.rememberMe.path}"/>
         <property name="secure" value="${crafter.security.cookie.rememberMe.secure}"/>
         <property name="httpOnly" value="${crafter.security.cookie.rememberMe.httpOnly}"/>
     </bean>

--- a/security-provider/src/main/resources/crafter/security/security.properties
+++ b/security-provider/src/main/resources/crafter/security/security.properties
@@ -17,16 +17,31 @@ crafter.security.authentication.cache.timeToIdle=300
 
 # How much time before the ticket cookie is expired in the browser, in seconds (-1 means when the browser closes)
 crafter.security.cookie.ticket.maxAge=-1
+# The path to which the cookie will be visible by the client
+crafter.security.cookie.ticket.path=/
+# Indicates whether the cookie should be only sent using a secure protocol, like HTTPS or SSL
 crafter.security.cookie.ticket.secure=false
+# If true, the cookie will be sent with an HttpOnly attribute, which tells the browser that it's not supposed to
+# be exposed to client-side scripting code
 crafter.security.cookie.ticket.httpOnly=true
 # How much time before the profile last modified cookie is expired in the browser, in seconds (-1 means when the
 # browser closes)
 crafter.security.cookie.profileLastModified.maxAge=-1
+# The path to which the cookie will be visible by the client
+crafter.security.cookie.profileLastModified.path=/
+# Indicates whether the cookie should be only sent using a secure protocol, like HTTPS or SSL
 crafter.security.cookie.profileLastModified.secure=false
+# If true, the cookie will be sent with an HttpOnly attribute, which tells the browser that it's not supposed to
+# be exposed to client-side scripting code
 crafter.security.cookie.profileLastModified.httpOnly=true
 # How much time before the remember me cookie is expired in the browser, in seconds
 crafter.security.cookie.rememberMe.maxAge=1296000
+# The path to which the cookie will be visible by the client
+crafter.security.cookie.rememberMe.path=/
+# Indicates whether the cookie should be only sent using a secure protocol, like HTTPS or SSL
 crafter.security.cookie.rememberMe.secure=false
+# If true, the cookie will be sent with an HttpOnly attribute, which tells the browser that it's not supposed to
+# be exposed to client-side scripting code
 crafter.security.cookie.rememberMe.httpOnly=true
 
 # The URL of the login form page


### PR DESCRIPTION
* The path of security provider cookies can now be specified through properties. This allows to have a different path for /crafter-profile-admin for example, and in this way Engine's authentication won't collide with the Admin Console authentication.