### PR TITLE
[develop] Fix broken link to reference module in OAS

### DIFF
--- a/api/src/main/api/profile-api.yaml
+++ b/api/src/main/api/profile-api.yaml
@@ -14,7 +14,7 @@ info:
         url: 'https://www.gnu.org/licenses/gpl-3.0.en.html'
 externalDocs:
     description: CrafterCMS - Profile
-    url: 'https://craftercms.com/docs/current/reference/modules/profile/index.html'
+    url: 'https://craftercms.com/docs/current/reference/modules/profile.html'
 tags:
     -   name: access_token
         description: Access token management


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix broken link to reference module in OAS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the external documentation link for the Crafter Profile API to direct users to a more general documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->